### PR TITLE
Add environment example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env and adjust values as needed.
+
+# FastAPI server port
+PORT=8000
+
+# OpenAI configuration
+OPENAI_API_KEY=your-openai-api-key
+# Optionally override the base URL for OpenAI API requests
+OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Ollama configuration
+# Base URL of the local Ollama server
+OLLAMA_BASE_URL=http://127.0.0.1:11434


### PR DESCRIPTION
## Summary
- add a `.env.example` template with documented defaults for backend configuration variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce29dc78188333be92abfe05b64df0